### PR TITLE
rework the lexer to keep track of source locations for each token

### DIFF
--- a/tests/02_collapse.php
+++ b/tests/02_collapse.php
@@ -7,9 +7,9 @@
 
 	function collapse_test($in, $out){
 		$obj = new SQLParser();
-		is_deeply($obj->collapse_tokens($in), $out);
+		is_deeply($obj->lex($in), $out);
 	}
 
 
-	collapse_test(array('a', 'b'), array('a', 'b'));
-	collapse_test(array('UNIQUE', 'key'), array('UNIQUE KEY'));
+	collapse_test('a b', array('a', 'b'));
+	collapse_test('UNIQUE key', array('UNIQUE KEY'));

--- a/tests/10_full.php
+++ b/tests/10_full.php
@@ -10,6 +10,7 @@
 		$lines = array();
 		foreach ($obj->tables as $table){
 			$lines[] = "TABLE:{$table['name']}";
+			$lines[] = "SQL:{$table['sql']}";
 			foreach ($table['fields'] as $field){
 				$lines[] = "-FIELD:{$field['name']}:{$field['type']}";
 			}
@@ -22,7 +23,14 @@
 	plan(1);
 
 
-	full_test("CREATE TABLE table_name (a INT);", array(
-		"TABLE:table_name",
-		"-FIELD:a:INT",
+	full_test("CREATE TABLE table_name (a INT);\n" .
+		  "-- ignored comment\n\n" .
+		  "CREATE TABLE t2 (b VARCHAR)\n\n;\n",
+		array(
+			"TABLE:table_name",
+			"SQL:CREATE TABLE table_name (a INT);",
+			"-FIELD:a:INT",
+			"TABLE:t2",
+			"SQL:CREATE TABLE t2 (b VARCHAR)\n\n;",
+			"-FIELD:b:VARCHAR",
 	));


### PR DESCRIPTION
In order to have the original CREATE TABLE text from the schema
available when using the parsed structure, rework the lexer so that
instead of extracting the substring tokens, it extracts tuples of
`[position, length]` and maintains these associations when collapsing
the token sequences.

This means we can include the original source text in a `sql` field
of the resulting parsed structure.