### PR TITLE
database support

### DIFF
--- a/tests/FullTest.php
+++ b/tests/FullTest.php
@@ -1,38 +1,183 @@
 <?php
-	use PHPUnit\Framework\TestCase;
 
-	final class FullTest extends TestCase{
+use PHPUnit\Framework\TestCase;
 
-		function full_test($sql, $expected){
+final class FullTest extends TestCase
+{
+    /**
+     * @param $sql
+     * @param $expected
+     * @dataProvider parseProvider
+     */
+    public function testBasicCases($sql, $expected)
+    {
+        $obj = new iamcal\SQLParser();
+        $tables = $obj->parse($sql);
 
-			$obj = new iamcal\SQLParser();
-			$obj->parse($sql);
+        $this->assertEquals($expected, $tables);
+    }
 
-			$lines = array();
-			foreach ($obj->tables as $table){
-				$lines[] = "TABLE:{$table['name']}";
-				$lines[] = "SQL:{$table['sql']}";
-				foreach ($table['fields'] as $field){
-					$lines[] = "-FIELD:{$field['name']}:{$field['type']}";
-				}
-			}
+    public function parseProvider()
+    {
+        return [
+            [
+                "CREATE TABLE table_name (a INT);\n"
+                . "-- ignored comment\n\n"
+                . "CREATE TABLE t2 (b VARCHAR)\n\n;\n",
+                [
+                    'table_name' => [
+                        'name' => 'table_name',
+                        'database' => null,
+                        'fields' => [
+                            [
+                                'name' => 'a',
+                                'type' => 'INT',
+                            ],
+                        ],
+                        'indexes' => [],
+                        'props' => [],
+                        'more' => [],
+                        'sql' => 'CREATE TABLE table_name (a INT);',
+                    ],
+                    't2' => [
+                        'name' => 't2',
+                        'database' => null,
+                        'fields' => [
+                            [
+                                'name' => 'b',
+                                'type' => 'VARCHAR',
+                            ],
+                        ],
+                        'indexes' => [],
+                        'props' => [],
+                        'more' => [],
+                        'sql' => "CREATE TABLE t2 (b VARCHAR)\n\n;",
+                    ],
 
-			$this->assertEquals($lines, $expected);
-		}
+                ]
+            ],
+            [
+                'CREATE TABLE DbName.TableName ( 
+                    id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT, 
+                    errcnt INT(10) UNSIGNED NOT NULL DEFAULT \'0\', 
+                    user_id INT UNSIGNED NOT NULL, 
+                    photo_id INT UNSIGNED NOT NULL, 
+                    place_id INT UNSIGNED NOT NULL, 
+                    next_processing_time TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP, 
+                    created TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP, 
+                    PRIMARY KEY (id), 
+                    KEY (place_id, next_processing_time), 
+                    UNIQUE KEY (user_id, place_id, photo_id) 
+                );',
+                [
+                    'DbName.TableName' => [
+                        'name' => 'TableName',
+                        'database' => 'DbName',
+                        'fields' => [
+                            [
+                                'name' => 'id',
+                                'type' => 'BIGINT',
+                                'unsigned' => true,
+                                'null' => false,
+                                'auto_increment' => true,
+                            ],
+                            [
+                                'name' => 'errcnt',
+                                'type' => 'INT',
+                                'length' => '10',
+                                'unsigned' => true,
+                                'null' => false,
+                                'default' => '0',
+                            ],
+                            [
+                                'name' => 'user_id',
+                                'type' => 'INT',
+                                'unsigned' => true,
+                                'null' => false,
+                            ],
+                            [
+                                'name' => 'photo_id',
+                                'type' => 'INT',
+                                'unsigned' => true,
+                                'null' => false,
+                            ],
+                            [
+                                'name' => 'place_id',
+                                'type' => 'INT',
+                                'unsigned' => true,
+                                'null' => false,
+                            ],
+                            [
+                                'name' => 'next_processing_time',
+                                'type' => 'TIMESTAMP',
+                                'null' => false,
+                                'default' => 'CURRENT_TIMESTAMP',
+                            ],
+                            [
+                                'name' => 'created',
+                                'type' => 'TIMESTAMP',
+                                'null' => false,
+                                'default' => 'CURRENT_TIMESTAMP',
+                            ],
+                        ],
+                        'indexes' => [
+                            [
+                                'type' => 'PRIMARY',
+                                'cols' =>
+                                    [
+                                        [
+                                            'name' => 'id',
+                                        ],
+                                    ],
+                            ],
+                            [
+                                'type' => 'INDEX',
+                                'cols' =>
+                                    [
+                                        [
+                                            'name' => 'place_id',
+                                        ],
+                                        [
+                                            'name' => 'next_processing_time',
+                                        ],
+                                    ],
+                            ],
+                            [
+                                'type' => 'UNIQUE',
+                                'cols' =>
+                                    [
+                                        [
+                                            'name' => 'user_id',
+                                        ],
+                                        [
+                                            'name' => 'place_id',
+                                        ],
+                                        [
+                                            'name' => 'photo_id',
+                                        ],
+                                    ],
+                            ],
+                        ],
+                        'props' => [],
+                        'more' => [],
+                        'sql' => 'CREATE TABLE DbName.TableName ( 
+                    id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT, 
+                    errcnt INT(10) UNSIGNED NOT NULL DEFAULT \'0\', 
+                    user_id INT UNSIGNED NOT NULL, 
+                    photo_id INT UNSIGNED NOT NULL, 
+                    place_id INT UNSIGNED NOT NULL, 
+                    next_processing_time TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP, 
+                    created TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP, 
+                    PRIMARY KEY (id), 
+                    KEY (place_id, next_processing_time), 
+                    UNIQUE KEY (user_id, place_id, photo_id) 
+                );',
+                    ],
 
+                ]
+            ]
 
-		function testBasicCases(){
+        ];
+    }
 
-			$this->full_test("CREATE TABLE table_name (a INT);\n" .
-				  "-- ignored comment\n\n" .
-				  "CREATE TABLE t2 (b VARCHAR)\n\n;\n",
-				array(
-					"TABLE:table_name",
-					"SQL:CREATE TABLE table_name (a INT);",
-					"-FIELD:a:INT",
-					"TABLE:t2",
-					"SQL:CREATE TABLE t2 (b VARCHAR)\n\n;",
-					"-FIELD:b:VARCHAR",
-			));
-		}
-	}
+}

--- a/tests/TablesTest.php
+++ b/tests/TablesTest.php
@@ -34,6 +34,16 @@
 			$this->assertEquals($tbl['like'], "bar");
 		}
 
+        function testCreateTableLikeWithDb(){
+
+            $tbl = $this->get_first_table("CREATE TABLE db.foo LIKE `db2`.`bar`");
+
+            $this->assertEquals($tbl['name'], "foo");
+            $this->assertEquals($tbl['database'], "db");
+            $this->assertEquals($tbl['like'], "bar");
+            $this->assertEquals($tbl['like_database'], "db2");
+        }
+
 
 		function get_first_table($str){
 			$obj = new iamcal\SQLParser();


### PR DESCRIPTION
Current parser don't work with queries like
`CREATE TABLE DbName.TableName`
and
`CREATE TABLE DbName.TableName LIKE DbName2.TableName2;`
This pull request add 'database' key to result array.