### PR TITLE
Some maintenance

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -2,84 +2,66 @@ name: Build
 
 on:
   push:
-    branches: [ master ]
+    branches: [master]
   pull_request:
-    branches: [ master ]
+    branches: [master]
 
 jobs:
   build:
-
-    runs-on: ubuntu-20.04
+    runs-on: ${{ matrix.operating-system }}
     strategy:
       matrix:
-        operating-system: ['ubuntu-20.04']
-        php-versions: ['8.0']
-        phpunit-versions: ['9.5.4']
+        operating-system: [ubuntu-latest]
+        php-versions: ["5.6", "7.0", "7.1", "7.2", "7.3", "7.4", "8.1", "8.2"]
         coverage: [false]
-        include:
-        - php-versions: '5.3'
-          phpunit-versions: '4.8.36'
-        - php-versions: '5.4'
-          phpunit-versions: '4.8.36'
-        - php-versions: '5.5'
-          phpunit-versions: '4.8.36'
-        - php-versions: '5.6'
-          phpunit-versions: '4.8.36'
-        - php-versions: '7.0'
-          phpunit-versions: '4.8.36'
-        - php-versions: '7.1'
-          phpunit-versions: '4.8.36'
-        - php-versions: '7.2'
-          phpunit-versions: '4.8.36'
-        - php-versions: '7.3'
-          phpunit-versions: '7.5.20'
-        - php-versions: '7.4'
-          phpunit-versions: '7.5.20'
-          coverage: true
-        - php-versions: '8.1'
-          phpunit-versions: '9.5.16'
 
     steps:
-    - name: Setup PHP
-      uses: shivammathur/setup-php@v2
-      with:
-        php-version: ${{ matrix.php-versions }}
-        coverage: xdebug
-        tools: phpunit:${{ matrix.phpunit-versions }}
+      - name: Checkout
+        uses: actions/checkout@v3
 
-    - uses: actions/checkout@v2
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php-versions }}
+          coverage: xdebug
+          tools: composer
+        env:
+          fail-fast: true
 
-    - run: composer remove phpunit/phpunit --dev --no-update
-    - run: composer remove php-coveralls/php-coveralls --dev --no-update
-    - run: cat composer.json
+      - name: Setup problem matchers for PHPUnit
+        run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
 
-    - name: Cache Composer packages
-      id: composer-cache
-      uses: actions/cache@v2
-      with:
-        path: vendor
-        key: ${{ runner.os }}-php-${{ matrix.php-versions }}-${{ hashFiles('**/composer.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-php-
+      - name: Validate composer
+        run: composer validate
 
-    - name: Install dependencies
-      run: composer install --prefer-source --no-interaction --dev
+      - name: Get composer cache directory
+        id: composer-cache
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
-    - name: Run tests
-      run: phpunit
-      if: ${{ !matrix.coverage }}
+      - name: Cache dependencies
+        uses: actions/cache@v3
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+          restore-keys: ${{ runner.os }}-composer-
 
-    - name: Run tests with coverage
-      run: |
-       mkdir -p build/logs
-       phpunit --coverage-clover build/logs/clover.xml
-       ls -l build/logs/
-      if: ${{ matrix.coverage }}
+      - name: Install dependencies
+        run: composer install --no-progress
 
-    - name: Upload coverage results to Coveralls
-      env:
-        COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: |
-        composer global require php-coveralls/php-coveralls
-        php-coveralls --coverage_clover=build/logs/clover.xml -v
-      if: ${{ matrix.coverage }}
+      - name: Run tests
+        run: composer test
+        if: ${{ !matrix.coverage }}
+
+      - name: Run tests with coverage
+        run: |
+          composer test-coverage
+          ls -l build/logs/
+        if: ${{ matrix.coverage }}
+
+      - name: Upload coverage results to Coveralls
+        env:
+          COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          composer global require php-coveralls/php-coveralls
+          php-coveralls --coverage_clover=build/logs/clover.xml -v
+        if: ${{ matrix.coverage }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 composer.phar
 composer.lock
-vendor/
-
+.phpunit.cache
+/vendor
+/build

--- a/README.md
+++ b/README.md
@@ -7,101 +7,109 @@ This library takes MySQL `CREATE TABLE` statements and returns a data structure 
 MySQL syntax [version 5.7](https://dev.mysql.com/doc/refman/5.7/en/create-table.html) is supported.
 This library does not try to validate input - the goal is to deconstruct valid `CREATE TABLE` statements.
 
-
 ## Installation
 
 You can install this package using composer. To add it to your `composer.json`:
 
-    composer require iamcal/sql-parser
+```plain
+composer require iamcal/sql-parser
+```
 
 You can then load it using the composer autoloader:
 
-    require_once 'vendor/autoload.php';
-    use iamcal\SQLParser;
+```php
+require_once 'vendor/autoload.php';
+use iamcal\SQLParser;
 
-    $parser = new SQLParser();
+$parser = new SQLParser();
+```
 
 If you don't use composer, you can skip the autoloader and include `src/SQLParser.php` directly.
-
 
 ## Usage
 
 To extract the tables defined in SQL:
 
-    $parser = new SQLParser();
-    $parser->parse($sql);
+```php
+$parser = new SQLParser();
+$parser->parse($sql);
 
-    print_r($parser->tables);
+print_r($parser->tables);
+```
 
-The `tables` property is an array of tables, each of which is a nested array structure defining the 
+The `tables` property is an array of tables, each of which is a nested array structure defining the
 table's structure:
 
-	CREATE TABLE `achievements_counts` (
-	  `achievement_id` int(10) unsigned NOT NULL,
-	  `num_players` int(10) unsigned NOT NULL,
-	  `date_updated` int(10) unsigned NOT NULL,
-	  PRIMARY KEY (`achievement_id`)
-	) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+```SQL
+CREATE TABLE `achievements_counts` (
+  `achievement_id` int(10) unsigned NOT NULL,
+  `num_players` int(10) unsigned NOT NULL,
+  `date_updated` int(10) unsigned NOT NULL,
+  PRIMARY KEY (`achievement_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+```
 
-
-	[
-		'achievements_counts' => [
-			'name' => 'achievements_counts',
-			'fields' => [
-				[
-					'name' => 'achievement_id',
-					'type' => 'INT',
-					'length' => '10',
-					'unsigned' => true,
-					'null' => false,
-				],
-				[
-					'name' => 'num_players',
-					'type' => 'INT',
-					'length' => '10',
-					'unsigned' => true,
-					'null' => false,
-				],
-				[
-					'name' => 'date_updated',
-					'type' => 'INT',
-					'length' => '10',
-					'unsigned' => true,
-					'null' => false,
-				],
-			],
-			'indexes' => [
-				[
-					'type' => 'PRIMARY',
-					'cols' => [
-						[
-							'name' => 'achievement_id',
-						],
-					],
-				],
-			],
-			'props' => [
-				'ENGINE' => 'InnoDB',
-				'CHARSET' => 'utf8',
-			],
-		],
-	]
+```php
+[
+    'achievements_counts' => [
+        'name' => 'achievements_counts',
+        'fields' => [
+            [
+                'name' => 'achievement_id',
+                'type' => 'INT',
+                'length' => '10',
+                'unsigned' => true,
+                'null' => false,
+            ],
+            [
+                'name' => 'num_players',
+                'type' => 'INT',
+                'length' => '10',
+                'unsigned' => true,
+                'null' => false,
+            ],
+            [
+                'name' => 'date_updated',
+                'type' => 'INT',
+                'length' => '10',
+                'unsigned' => true,
+                'null' => false,
+            ],
+        ],
+        'indexes' => [
+            [
+                'type' => 'PRIMARY',
+                'cols' => [
+                    [
+                        'name' => 'achievement_id',
+                    ],
+                ],
+            ],
+        ],
+        'props' => [
+            'ENGINE' => 'InnoDB',
+            'CHARSET' => 'utf8',
+        ],
+    ],
+]
+```
 
 You can also use the lexer directly to work with other piece of SQL:
 
-    $parser = new SQLParser();
-    $parser->lex($sql);
+```php
+$parser = new SQLParser();
+$parser->lex($sql);
 
-    print($parser->tokens);
+print($parser->tokens);
+```
 
-The `tokens` property contains an array of tokens. SQL keywords are returned as uppercase, 
+The `tokens` property contains an array of tokens. SQL keywords are returned as uppercase,
 with multi-word terms (e.g. `DEFAULT CHARACTER SET`) as a single token. Strings and escaped
 identifiers are not further processed; they are returned exactly as expressed in the input SQL.
 
-By default, the tokenizer will ignore unterminated comments and strings, and stop parsing at 
+By default, the tokenizer will ignore unterminated comments and strings, and stop parsing at
 that point, producing no further tokens. You can set `$parser->throw_on_bad_syntax = true;` to
 throw an exception of type `iamcal\SQLParserSyntaxException` instead.
-
 
 ## Performance
 
@@ -113,17 +121,15 @@ seconds just to lex the input. This was obviously not a great option.
 The current implementation uses a hand-written lexer which takes around 140ms to lex the same
 input and imposes less odd restrictions. This seems to be the way to go.
 
-
 ## History
 
 This library was created to parse multiple `CREATE TABLE` schemas and compare them, so
 figure out what needs to be done to migrate one to the other.
 
 This is based on the system used at b3ta, Flickr and then Tiny Speck to check the differences
-between production and development databases and between shard instances. The original system 
+between production and development databases and between shard instances. The original system
 just showed a diff (see [SchemaDiff](https://github.com/iamcal/SchemaDiff)), but that was a bit
 of a pain.
-
 
 ## Unsupported features
 
@@ -141,11 +147,11 @@ MySQL table definitions have a *lot* of options, so some things just aren't supp
 If you need support for one of these features, open an issue or (better) send a pull request with tests.
 
 The specs for each of the four field groupings can be found here:
+
 * https://dev.mysql.com/doc/refman/5.7/en/numeric-type-syntax.html
 * https://dev.mysql.com/doc/refman/5.7/en/date-and-time-type-syntax.html
 * https://dev.mysql.com/doc/refman/5.7/en/string-type-syntax.html
 * https://dev.mysql.com/doc/refman/5.7/en/spatial-type-overview.html
-
 
 ## Alternatives
 
@@ -153,7 +159,6 @@ If you're using PHP, then [Modyllic](https://github.com/onlinebuddies/modyllic) 
 
 If you're using Hack, then [Hack SQL Fake](https://github.com/slackhq/hack-sql-fake) allows you to parse SQL and create a fake MySQL
 server for testing, with many (but not all!) features of MySQL.
-
 
 ## Publishing
 

--- a/composer.json
+++ b/composer.json
@@ -11,11 +11,19 @@
 	],
 	"autoload": {
 		"psr-4": {
-			"iamcal\\" : "src"
+			"iamcal\\": "src"
 		}
 	},
 	"require-dev": {
-		"phpunit/phpunit": "~4.8",
-		"php-coveralls/php-coveralls": "~1.0"
+		"phpunit/phpunit": "^5|^6|^7|^8|^9",
+		"php-coveralls/php-coveralls": "^1.0"
+	},
+	"scripts": {
+		"test": "vendor/bin/phpunit -c phpunit.xml.dist",
+		"test-coverage": "vendor/bin/phpunit -c phpunit.xml.dist --coverage-clover build/logs/clover.xml"
+	},
+	"scripts-descriptions": {
+		"test": "Run tests",
+		"test-coverage": "Run tests with coverage"
 	}
 }

--- a/src/SQLParser.php
+++ b/src/SQLParser.php
@@ -17,6 +17,8 @@ class SQLParser{
 	public $find_single_table = false;
 	public $throw_on_bad_syntax = false;
 
+	public $sql;
+
 	public function parse($sql){
 
 		// stashes tokens and source_map in $this


### PR DESCRIPTION
Improved test support by fixing phpunit version constrain in `composer.json`.  Composer picks the dependency based on PHP version match.

Added commands to Composer file. You can run now `composer test` and `composer test-coverage`.

Removed a public property that went deprecated in 8.2.

Added code blocks at `README.md`.

At `php.yml` workflow fixed the matrix and re-organized PHP setup to be composer driven. Fixed action cache for self-hosted runners.