### PR TITLE
feat: add `.gitattributes`

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,15 @@
+* text=auto
+
+# Path-based git attributes
+# https://git-scm.com/docs/gitattributes
+
+# Ignore all tests and documentation with "export-ignore".
+/.gitattributes     export-ignore
+/.github            export-ignore
+/.gitignore         export-ignore
+/data               export-ignore
+/Makefile           export-ignore
+/phpunit.xml.dist   export-ignore
+/tests              export-ignore
+/run.php            export-ignore
+/x.php              export-ignore


### PR DESCRIPTION
This adds a `.gitattributes` file to exclude tests and other files from the `vendor` archive when installing via Composer.